### PR TITLE
[TECH-2126] Use wildcard instead of version variable for assets upload

### DIFF
--- a/package.json
+++ b/package.json
@@ -148,7 +148,7 @@
       "release": true,
       "requireBranch": "main",
       "assets": [
-        "build/native-base-v${version}.tgz"
+        "build/native-base-v*.tgz"
       ]
     },
     "plugins": {


### PR DESCRIPTION
Whoops, looks like `${version}` doesn't actually get interpolated here...https://github.com/fireflyhealth/NativeBase/actions/runs/17924853820/job/50968300551