### PR TITLE
[TECH-2126] Do not use deprecated `BackHandler.removeEventListener`

### DIFF
--- a/src/hooks/useKeyboardDismissable.ts
+++ b/src/hooks/useKeyboardDismissable.ts
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useEffect } from 'react';
-import { BackHandler } from 'react-native';
+import { BackHandler, NativeEventSubscription } from 'react-native';
 
 type IParams = {
   enabled?: boolean;
@@ -48,12 +48,14 @@ export function useBackHandler({ enabled, callback }: IParams) {
       callback();
       return true;
     };
+    let listener: NativeEventSubscription | undefined;
     if (enabled) {
-      BackHandler.addEventListener('hardwareBackPress', backHandler);
+      listener = BackHandler.addEventListener('hardwareBackPress', backHandler);
     } else {
-      BackHandler.removeEventListener('hardwareBackPress', backHandler);
+      listener?.remove();
     }
-    return () =>
-      BackHandler.removeEventListener('hardwareBackPress', backHandler);
+    return () => {
+      listener?.remove();
+    };
   }, [enabled, callback]);
 }


### PR DESCRIPTION
[BackHandler.removeEventListener](https://github.com/GeekyAnts/NativeBase/blob/master/src/hooks/useKeyboardDismissable.ts#L54) was [removed in React Native 0.77](https://reactnative-archive-august-2025.netlify.app/blog/2025/01/21/version-0.77#other-breaking-changes).